### PR TITLE
style: refactor bad smell UnnecessaryToStringCall

### DIFF
--- a/src/main/java/spoon/ContractVerifier.java
+++ b/src/main/java/spoon/ContractVerifier.java
@@ -235,7 +235,7 @@ public class ContractVerifier {
 					return;
 				}
 				final CtExecutable<T> executableDeclaration = reference.getExecutableDeclaration();
-				assertNotNull("cannot find decl for " + reference , executableDeclaration);
+				assertNotNull("cannot find decl for " + reference, executableDeclaration);
 				assertEquals(reference.getSimpleName(), executableDeclaration.getSimpleName());
 
 				// when a generic type is used in a parameter and return type, the shadow type doesn't have these information.
@@ -265,7 +265,7 @@ public class ContractVerifier {
 				}
 
 				if (reference.getDeclaration() == null && CtShadowable.class.isAssignableFrom(executableDeclaration.getClass())) {
-					assertTrue("execDecl at " + reference  + " must be shadow ", ((CtShadowable) executableDeclaration).isShadow());
+					assertTrue("execDecl at " + reference + " must be shadow ", ((CtShadowable) executableDeclaration).isShadow());
 				}
 
 			}
@@ -400,7 +400,7 @@ public class ContractVerifier {
 			CtExpression assigned = assign.getAssigned();
 			if (!(assigned instanceof CtFieldWrite
 					|| assigned instanceof CtVariableWrite || assigned instanceof CtArrayWrite)) {
-				throw new AssertionError("AssignmentContract error:" + assign.getPosition() + "\n" + assign  + "\nAssigned is " + assigned.getClass());
+				throw new AssertionError("AssignmentContract error:" + assign.getPosition() + "\n" + assign + "\nAssigned is " + assigned.getClass());
 			}
 		}
 	}
@@ -464,7 +464,7 @@ public class ContractVerifier {
 			Exception firstStack = allElements.put(ele, secondStack);
 			if (firstStack != null) {
 				if (firstStack == dummyException) {
-					fail("The Spoon model is not a tree. The " + ele.getClass().getSimpleName() + ":" + ele  + " is shared");
+					fail("The Spoon model is not a tree. The " + ele.getClass().getSimpleName() + ":" + ele + " is shared");
 				}
 				//the element ele was already visited. It means it used on more places
 				//report the stacktrace of first and second usage, so that place can be found easily

--- a/src/main/java/spoon/ContractVerifier.java
+++ b/src/main/java/spoon/ContractVerifier.java
@@ -217,7 +217,7 @@ public class ContractVerifier {
 					return;
 				}
 				final CtType<T> typeDeclaration = reference.getTypeDeclaration();
-				assertNotNull(reference.toString() + " cannot be found in ", typeDeclaration);
+				assertNotNull(reference + " cannot be found in ", typeDeclaration);
 				assertEquals(reference.getSimpleName(), typeDeclaration.getSimpleName());
 				assertEquals(reference.getQualifiedName(), typeDeclaration.getQualifiedName());
 
@@ -235,7 +235,7 @@ public class ContractVerifier {
 					return;
 				}
 				final CtExecutable<T> executableDeclaration = reference.getExecutableDeclaration();
-				assertNotNull("cannot find decl for " + reference.toString(), executableDeclaration);
+				assertNotNull("cannot find decl for " + reference , executableDeclaration);
 				assertEquals(reference.getSimpleName(), executableDeclaration.getSimpleName());
 
 				// when a generic type is used in a parameter and return type, the shadow type doesn't have these information.
@@ -265,7 +265,7 @@ public class ContractVerifier {
 				}
 
 				if (reference.getDeclaration() == null && CtShadowable.class.isAssignableFrom(executableDeclaration.getClass())) {
-					assertTrue("execDecl at " + reference.toString() + " must be shadow ", ((CtShadowable) executableDeclaration).isShadow());
+					assertTrue("execDecl at " + reference  + " must be shadow ", ((CtShadowable) executableDeclaration).isShadow());
 				}
 
 			}
@@ -400,7 +400,7 @@ public class ContractVerifier {
 			CtExpression assigned = assign.getAssigned();
 			if (!(assigned instanceof CtFieldWrite
 					|| assigned instanceof CtVariableWrite || assigned instanceof CtArrayWrite)) {
-				throw new AssertionError("AssignmentContract error:" + assign.getPosition() + "\n" + assign.toString() + "\nAssigned is " + assigned.getClass());
+				throw new AssertionError("AssignmentContract error:" + assign.getPosition() + "\n" + assign  + "\nAssigned is " + assigned.getClass());
 			}
 		}
 	}
@@ -464,7 +464,7 @@ public class ContractVerifier {
 			Exception firstStack = allElements.put(ele, secondStack);
 			if (firstStack != null) {
 				if (firstStack == dummyException) {
-					fail("The Spoon model is not a tree. The " + ele.getClass().getSimpleName() + ":" + ele.toString() + " is shared");
+					fail("The Spoon model is not a tree. The " + ele.getClass().getSimpleName() + ":" + ele  + " is shared");
 				}
 				//the element ele was already visited. It means it used on more places
 				//report the stacktrace of first and second usage, so that place can be found easily


### PR DESCRIPTION
# Repairing Code Style Issues
## UnnecessaryToStringCall
The `toString()` method is not needed in cases the underlying method handles the conversion. Also calling toString() on a String is redundant. Removing them simplifies the code.
<!-- fingerprint:2078411996 -->
<!-- fingerprint:183013778 -->
<!-- fingerprint:1276421466 -->
<!-- fingerprint:2124982138 -->
<!-- fingerprint:-988691246 -->
# Repairing Code Style Issues
* UnnecessaryToStringCall (5)
