### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/src/main/java/spoon/support/gui/SpoonObjectFieldsTable.java
+++ b/src/main/java/spoon/support/gui/SpoonObjectFieldsTable.java
@@ -22,7 +22,7 @@ import spoon.Launcher;
 
 
 public class SpoonObjectFieldsTable extends JFrame {
-	public class SpoonObjectTableModel extends AbstractTableModel {
+	public static class SpoonObjectTableModel extends AbstractTableModel {
 
 		private static final long serialVersionUID = 1L;
 

--- a/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
+++ b/src/main/java/spoon/support/reflect/declaration/CtClassImpl.java
@@ -267,7 +267,7 @@ public class CtClassImpl<T> extends CtTypeImpl<T> implements CtClass<T> {
 		}
 	}
 
-	private class NewInstanceClassloader extends URLClassLoader {
+	private static class NewInstanceClassloader extends URLClassLoader {
 		NewInstanceClassloader(File binaryOutputDirectory) throws MalformedURLException {
 			super(new URL[] { binaryOutputDirectory.toURI().toURL()});
 		}


### PR DESCRIPTION
# Repairing Code Style Issues
## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:-153577585 -->
<!-- fingerprint:1026199369 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (2)
