### PR TITLE
refactor: refactor bad smell RedundantArrayCreation

### DIFF
--- a/src/main/java/spoon/reflect/factory/AnnotationFactory.java
+++ b/src/main/java/spoon/reflect/factory/AnnotationFactory.java
@@ -111,7 +111,7 @@ public class AnnotationFactory extends TypeFactory {
 		} else {
 			Method m;
 			try {
-				m = annotation.getAnnotationType().getActualClass().getMethod(annotationElementName, new Class[0]);
+				m = annotation.getAnnotationType().getActualClass().getMethod(annotationElementName);
 			} catch (Exception ex) {
 				annotation.addValue(annotationElementName, value);
 				return annotation;


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## RedundantArrayCreation
Creating a empty array for calling varargs methods is redundant. You can call the method directly without the array. The fix is to remove the empty array.
<!-- fingerprint:-378612647 -->
# Repairing Code Style Issues
* RedundantArrayCreation (1)
